### PR TITLE
improvement: Change power profile only if it is not already set

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -34,22 +34,25 @@ impl PowerClient {
 
         Ok(r)
     }
+
+    fn set_profile(&mut self, profile: &str) -> Result<(), String> {
+        println!("setting power profile to {}", profile);
+        self.call_method::<bool>(profile, None)?;
+        Ok(())
+    }
 }
 
 impl Power for PowerClient {
     fn performance(&mut self) -> Result<(), String> {
-        println!("setting power profile to performance");
-        self.call_method::<bool>("Performance", None).map(|_| ())
+        self.set_profile("Performance")
     }
 
     fn balanced(&mut self) -> Result<(), String> {
-        println!("setting power profile to balanced");
-        self.call_method::<bool>("Balanced", None).map(|_| ())
+        self.set_profile("Balanced")
     }
 
     fn battery(&mut self) -> Result<(), String> {
-        println!("setting power profile to battery");
-        self.call_method::<bool>("Battery", None).map(|_| ())
+        self.set_profile("Battery")
     }
 
     fn get_graphics(&mut self) -> Result<String, String> {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -81,6 +81,11 @@ impl PowerDaemon {
         func: fn(&mut Vec<ProfileError>, bool),
         name: &str,
     ) -> Result<(), String> {
+        if &self.power_profile == name {
+            info!("profile was already set");
+            return Ok(())
+        }
+
         func(&mut self.profile_errors, self.initial_set);
 
         let message =


### PR DESCRIPTION
Queries the current power profile before attempting to change it.
If it is the requested change is the same as the current profile, the system will not attempt to switch.