### PR TITLE
Add GetDefaultGraphics DBus method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -56,6 +56,11 @@ impl Power for PowerClient {
         self.set_profile("Battery")
     }
 
+    fn get_default_graphics(&mut self) -> Result<String, String> {
+        let r = self.call_method::<bool>("GetDefaultGraphics", None)?;
+        r.get1().ok_or_else(|| "return value not found".to_string())
+    }
+
     fn get_graphics(&mut self) -> Result<String, String> {
         let r = self.call_method::<bool>("GetGraphics", None)?;
         r.get1().ok_or_else(|| "return value not found".to_string())

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -140,6 +140,10 @@ impl Power for PowerDaemon {
         self.apply_profile(performance, "Performance").map_err(err_str)
     }
 
+    fn get_default_graphics(&mut self) -> Result<String, String> {
+        self.graphics.get_default_graphics().map_err(err_str)
+    }
+
     fn get_graphics(&mut self) -> Result<String, String> {
         self.graphics.get_vendor().map_err(err_str)
     }
@@ -221,6 +225,7 @@ pub async fn daemon() -> Result<(), String> {
         sync_action_method(b, "Performance", PowerDaemon::performance);
         sync_action_method(b, "Balanced", PowerDaemon::balanced);
         sync_action_method(b, "Battery", PowerDaemon::battery);
+        sync_get_method(b, "GetDefaultGraphics", "vendor", PowerDaemon::get_default_graphics);
         sync_get_method(b, "GetGraphics", "vendor", PowerDaemon::get_graphics);
         sync_set_method(b, "SetGraphics", "vendor", |d, s: String| d.set_graphics(&s));
         sync_get_method(b, "GetProfile", "profile", PowerDaemon::get_profile);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub trait Power {
     fn performance(&mut self) -> Result<(), String>;
     fn balanced(&mut self) -> Result<(), String>;
     fn battery(&mut self) -> Result<(), String>;
+    fn get_default_graphics(&mut self) -> Result<String, String>;
     fn get_graphics(&mut self) -> Result<String, String>;
     fn get_profile(&mut self) -> Result<String, String>;
     fn get_switchable(&mut self) -> Result<bool, String>;


### PR DESCRIPTION
Add a new DBus method to get the graphics mode a product should use by
default.

Only System76 models will default to "hybrid"; Other vendors will
default to "nvidia". Some models, such as those without NVIDIA RTD3
power management, should default to "integrated" instead.