### PR TITLE
Document that a reboot is required after switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Graphics Modes
 
+A reboot is **required** for changes to take effect after switching modes.
+
 ### Integrated
 
 The integrated graphics controller on the Intel or AMD CPU is used exclusively.

--- a/src/client.rs
+++ b/src/client.rs
@@ -84,7 +84,11 @@ impl Power for PowerClient {
 
     fn set_graphics(&mut self, vendor: &str) -> Result<(), String> {
         println!("setting graphics to {}", vendor);
-        self.call_method::<&str>("SetGraphics", Some(vendor)).map(|_| ())
+        let r = self.call_method::<&str>("SetGraphics", Some(vendor)).map(|_| ());
+        if r.is_ok() {
+            println!("reboot for changes to take effect");
+        }
+        r
     }
 
     fn get_graphics_power(&mut self) -> Result<bool, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
                 .long_about(
                     "Query or set the graphics mode.\n\n - If an argument is not provided, the \
                      graphics profile will be queried\n - Otherwise, that profile will be set, if \
-                     it is a valid profile",
+                     it is a valid profile\n\nA reboot is required after switching modes.",
                 )
                 .subcommand(
                     SubCommand::with_name("compute")


### PR DESCRIPTION
Switching graphics modes requires a reboot for changes to take effect as
it modifies module loading rules that happen during early boot.